### PR TITLE
Add cover-icon-element.js

### DIFF
--- a/cover-icon-element.js
+++ b/cover-icon-element.js
@@ -1,0 +1,59 @@
+class CoverIconElement extends Polymer.Element {
+
+  static dataImage4 = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%234d4d4d' preserveAspectRatio='xMidYMid meet' focusable='false' viewBox='0 0 24 24'%3E%3Cg%3E%3Cpath d='M3 4H21V8H19V20H17V8H7V20H5V8H3V4'%3E%3C/path%3E%3Cpath d='M3 9H16V11H8V9' opacity='1'%3E%3C/path%3E%3Cpath d='M3 12H16V14H8V12' opacity='1'%3E%3C/path%3E%3Cpath d='M3 15H16V17H8V15' opacity='1'%3E%3C/path%3E%3Cpath d='M3 18H16V20H8V18' opacity='1'%3E%3C/path%3E%3C/g%3E%3C/svg%3E";
+
+  static dataImage3 = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%234d4d4d' preserveAspectRatio='xMidYMid meet' focusable='false' viewBox='0 0 24 24'%3E%3Cg%3E%3Cpath d='M3 4H21V8H19V20H17V8H7V20H5V8H3V4'%3E%3C/path%3E%3Cpath d='M3 9H16V11H8V9' opacity='1'%3E%3C/path%3E%3Cpath d='M3 12H16V14H8V12' opacity='1'%3E%3C/path%3E%3Cpath d='M3 15H16V17H8V15' opacity='1'%3E%3C/path%3E%3Cpath d='M3 18H16V20H8V18' opacity='0.3'%3E%3C/path%3E%3C/g%3E%3C/svg%3E";
+
+  static dataImage2 = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%234d4d4d' preserveAspectRatio='xMidYMid meet' focusable='false' viewBox='0 0 24 24'%3E%3Cg%3E%3Cpath d='M3 4H21V8H19V20H17V8H7V20H5V8H3V4'%3E%3C/path%3E%3Cpath d='M3 9H16V11H8V9' opacity='1'%3E%3C/path%3E%3Cpath d='M3 12H16V14H8V12' opacity='1'%3E%3C/path%3E%3Cpath d='M3 15H16V17H8V15' opacity='0.3'%3E%3C/path%3E%3Cpath d='M3 18H16V20H8V18' opacity='0.3'%3E%3C/path%3E%3C/g%3E%3C/svg%3E";
+
+  static dataImage1 = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%234d4d4d' preserveAspectRatio='xMidYMid meet' focusable='false' viewBox='0 0 24 24'%3E%3Cg%3E%3Cpath d='M3 4H21V8H19V20H17V8H7V20H5V8H3V4'%3E%3C/path%3E%3Cpath d='M3 9H16V11H8V9' opacity='1'%3E%3C/path%3E%3Cpath d='M3 12H16V14H8V12' opacity='0.3'%3E%3C/path%3E%3Cpath d='M3 15H16V17H8V15' opacity='0.3'%3E%3C/path%3E%3Cpath d='M3 18H16V20H8V18' opacity='0.3'%3E%3C/path%3E%3C/g%3E%3C/svg%3E";
+
+  static dataImage0 = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%234d4d4d' preserveAspectRatio='xMidYMid meet' focusable='false' viewBox='0 0 24 24'%3E%3Cg%3E%3Cpath d='M3 4H21V8H19V20H17V8H7V20H5V8H3V4'%3E%3C/path%3E%3Cpath d='M3 9H16V11H8V9' opacity='0.3'%3E%3C/path%3E%3Cpath d='M3 12H16V14H8V12' opacity='0.3'%3E%3C/path%3E%3Cpath d='M3 15H16V17H8V15' opacity='0.3'%3E%3C/path%3E%3Cpath d='M3 18H16V20H8V18' opacity='0.3'%3E%3C/path%3E%3C/g%3E%3C/svg%3E";
+
+  setImage(hass) {
+    if (hass && this._config) {
+      let image = CoverIconElement.dataImage0;
+
+      if (this._config.entity) {
+        const stateObj = hass.states[this._config.entity];
+        if (stateObj) {
+          const position = stateObj.attributes.current_position;
+
+          if (position === 0) {
+            image = CoverIconElement.dataImage4;
+          } else if (position > 0 && position <= 50) {
+            image = CoverIconElement.dataImage3;
+          } else if (position > 50 && position <= 77) {
+            image = CoverIconElement.dataImage2;
+          } else if (position > 77 && position <= 99) {
+            image = CoverIconElement.dataImage1;
+          }
+        }
+      }
+
+      if (this.img && this.prevImage !== image) {
+        this.prevImage = image;
+        this.img.setConfig({
+          ...this._config,
+          image: image
+        });
+      }
+    }
+  }
+
+  async setConfig(config) {
+    if (!this.img) {
+      this.img = document.createElement('hui-image-element');
+      this.appendChild(this.img);
+    }
+    this._config = config;
+    this.setImage();
+  }
+
+  set hass(hass) {
+    this.img.hass = hass;
+    this.setImage(hass);
+  }
+}
+
+customElements.define('cover-icon-element', CoverIconElement);


### PR DESCRIPTION
Adds a new element to be used with cover elements which visually displays the open position percentage. 

<img width="83" alt="Screenshot 2020-10-31 at 00 06 57" src="https://user-images.githubusercontent.com/1107697/97766170-330dcf80-1b0d-11eb-811c-f8ee74c51b30.png">
<img width="84" alt="Screenshot 2020-10-31 at 00 07 05" src="https://user-images.githubusercontent.com/1107697/97766169-32753900-1b0d-11eb-9116-6f61c64c78e0.png">
<img width="86" alt="Screenshot 2020-10-31 at 00 07 37" src="https://user-images.githubusercontent.com/1107697/97766168-32753900-1b0d-11eb-9d3b-54778cba3851.png">
<img width="82" alt="Screenshot 2020-10-31 at 00 08 01" src="https://user-images.githubusercontent.com/1107697/97766167-31dca280-1b0d-11eb-9213-f886dd4f611c.png">
<img width="88" alt="Screenshot 2020-10-31 at 00 08 11" src="https://user-images.githubusercontent.com/1107697/97766166-30ab7580-1b0d-11eb-99d1-79c25ad0aa10.png">