### PR TITLE
Fix color override not working when entity state is off

### DIFF
--- a/cover-icon-element.js
+++ b/cover-icon-element.js
@@ -35,6 +35,9 @@ class CoverIconElement extends HTMLElement {
         this.prevImage = image;
         this.img.setConfig({
           ...this._config,
+          // We need to set a non false-ish filter, otherwise the hui-image's
+          // DEFAULT_FILTER (greyscale(100%)) gets applied when entity state is 'off'
+          filter: this._config.filter || " ",
           image: image
         });
       }


### PR DESCRIPTION
Prevent hui-image DEFAULT_FILTER from being applied when state="off"

![screenshot](https://user-images.githubusercontent.com/1107697/141842257-2ef768c8-ab75-40c1-b702-c63a266f65f7.png)

Specifying a filter should still work.

Fixes #12 